### PR TITLE
ci(firebase-actions): fix typo error in firebase

### DIFF
--- a/.github/workflows/firebase-hosting-alpha.yml
+++ b/.github/workflows/firebase-hosting-alpha.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           files: "build"
       - name: Deploy to SWS Pocket dev environment
-        if: steps.check_build.outputs.files.exists == 'true'
+        if: steps.check_build.outputs.files_exists == 'true'
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/firebase-hosting-beta.yml
+++ b/.github/workflows/firebase-hosting-beta.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           files: "build"
       - name: Deploy to SWS Pocket to beta environment
-        if: steps.check_build.outputs.files.exists == 'true'
+        if: steps.check_build.outputs.files_exists == 'true'
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           files: "build"
       - name: Deploy SWS Pocket to Production
-        if: steps.check_build.outputs.files.exists == 'true'
+        if: steps.check_build.outputs.files_exists == 'true'
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
# Description

This pull will fix a typo error that will cause the actions to deploy the app on Firebase even if no build was generated

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
